### PR TITLE
Cheat 001

### DIFF
--- a/app/src/main/java/com/example/cheat/BluetoothConnectivity.kt
+++ b/app/src/main/java/com/example/cheat/BluetoothConnectivity.kt
@@ -30,6 +30,7 @@ class BluetoothConnectivity constructor(cnt : Context, blt : BluetoothAdapter){
 
     private val serviceName: String = "CHEAT"
     private val serviceUUID: UUID = UUID.fromString("0b538899-008d-40ed-a0dc-6e657c3be729")
+    private val deviceNameConnectionMap: HashMap<String, ConnectedThread> = HashMap<String, ConnectedThread>();
 
     private var connectedThread : ConnectedThread? = null;
 
@@ -158,7 +159,9 @@ class BluetoothConnectivity constructor(cnt : Context, blt : BluetoothAdapter){
     }
 
     fun manageMyConnectedThread(socket : BluetoothSocket, cp : String) {
-        connectedThread = ConnectedThread(socket, cp);
+        val newThread = ConnectedThread(socket, cp);
+        connectedThread = newThread;
+        deviceNameConnectionMap.put(cp, newThread);
         connectedThread!!.start();
     }
 
@@ -217,7 +220,7 @@ class BluetoothConnectivity constructor(cnt : Context, blt : BluetoothAdapter){
             mmSocket?.use { socket ->
                 // Connect to the remote device through the socket. This call blocks
                 // until it succeeds or throws an exception.
-                if(!socket.isConnected) {
+                if(!socket.isConnected && !deviceNameConnectionMap.containsKey(dev.name)) {
                     Log.d(TAG, "Starting connecting to " + dev.name);
                     socket.connect();
                     manageMyConnectedThread(socket, dev.name);


### PR DESCRIPTION
We fixed the connectivity problem, but the chat history isn't ideal. Assuming the following scenario where D1 and D2 are devices:

D1: Connect to D2
D2: Send message "message1"
D1: Send message "message2"
D1: Go back to connect screen
D1: Connect to D2

then D1 will have both "message1" and "message2" but D2 will have no message in its' history.

Not ideal, but previously it worked like

D1: Connect to D2
D2: Send message "message1"
D1: Send message "message2"
D1: Go back to connect screen
D1: Connect to D2
*D1 crashes and can't chat until devices have been manually unpaired*